### PR TITLE
Offering the possibility to use custom TestRunner classes while using django_jenkins plugin

### DIFF
--- a/django_jenkins/management/commands/__init__.py
+++ b/django_jenkins/management/commands/__init__.py
@@ -40,14 +40,17 @@ class TaskListCommand(BaseCommand):
                     signal.connect(signal_handler)
         
         # run
-        TestRunner = get_runner(settings)
+		try:
+			TestRunner = get_runner(settings)
 
-        if not issubclass(TestRunner, CITestSuiteRunner):
-            raise ValueError('Your custom TestRunner should extend the CITestSuiteRunner class.')
+			if not issubclass(TestRunner, CITestSuiteRunner):
+				raise ValueError('Your custom TestRunner should extend the CITestSuiteRunner class.')
 
-        test_runner = TestRunner(output_dir=options['output_dir'], interactive=False, debug=options['debug'])
-        failures = test_runner.run_tests(test_labels)
+			test_runner = TestRunner(output_dir=options['output_dir'], interactive=False, debug=options['debug'])
+		except:
+			test_runner = CITestSuiteRunner(output_dir=options['output_dir'], interactive=False, debug=options['debug'])
 
+		failures = test_runner.run_tests(test_labels)
         if failures:
             sys.exit(bool(failures))
 


### PR DESCRIPTION
Hi,

I'm working on a project where I need to do some specific business for the test database setup (mainly because I use django multi-db support), so I need to use a custom TestRunner class where I have overwritten the setup_databases method.

As I'm also using jenkins for CI, I need django_jenkins to be able to use my custom TestRunner class.

I think it does make sense to have it by default in your nice plugin.

Cheers,
Christophe
