### PR TITLE
VE support / test app now works with newer Django

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
 .cache
-.ve*
+.ve2?
 .coverage
 *.pyc
 reports

--- a/tests/manage.py
+++ b/tests/manage.py
@@ -2,55 +2,9 @@
 # -*- coding: utf-8 -*-
 import sys
 from os import path
-import shutil, sys, virtualenv, subprocess
 from django.core.management import execute_manager
 
 PROJECT_ROOT = path.dirname(path.abspath(path.dirname(__file__)))
-REQUIREMENTS = path.join(PROJECT_ROOT, 'tests', 'requirements.pip')
-
-VE_ROOT = path.join(PROJECT_ROOT, '.ve')
-VE_TIMESTAMP = path.join(VE_ROOT, 'timestamp')
-
-envtime = path.exists(VE_ROOT) and path.getmtime(VE_ROOT) or 0
-envreqs = path.exists(VE_TIMESTAMP) and path.getmtime(VE_TIMESTAMP) or 0
-envspec = path.getmtime(REQUIREMENTS)
-
-def go_to_ve():
-    # going into ve
-    if not sys.prefix == VE_ROOT:
-        if sys.platform == 'win32':
-            python = path.join(VE_ROOT, 'Scripts', 'python.exe')
-        else:
-            python = path.join(VE_ROOT, 'bin', 'python')
-            
-        retcode = subprocess.call([python, __file__] + sys.argv[1:])
-        sys.exit(retcode)
-
-update_ve = 'update_ve' in sys.argv
-if update_ve or envtime < envspec or envreqs < envspec:
-    if update_ve:
-        # install ve
-        if envtime < envspec:
-            if path.exists(VE_ROOT):
-                shutil.rmtree(VE_ROOT)
-            virtualenv.logger = virtualenv.Logger(consumers=[])
-            virtualenv.create_environment(VE_ROOT, site_packages=True)
-
-        go_to_ve()    
-
-        # check requirements
-        if update_ve or envreqs < envspec:
-            import pip
-            pip.main(initial_args=['install', '-r', REQUIREMENTS])
-            file(VE_TIMESTAMP, 'w').close()
-        sys.exit(0)
-    else:
-        print "VirtualEnv need to be updated"
-        print "Run ./manage.py update_ve"
-        sys.exit(1)
-
-go_to_ve()
-
 sys.path.insert(0, PROJECT_ROOT)
 
 try:


### PR DESCRIPTION
Hi,

I had problems to run the test app for django-jenkins as the settingy.py seem to be for a different (older?) version of django.

Furthermore I added virtualenv support, so I can now use Jenkins with the test app - it works.

Maybe you want to use my changes as they'd improve django-jenkins.

Best regards,
Achim.
