### PR TITLE
coverage: More precise source inclusion/omission

### DIFF
--- a/django_jenkins/tasks/with_coverage.py
+++ b/django_jenkins/tasks/with_coverage.py
@@ -62,11 +62,15 @@ class Task(BaseTask):
         if not hasattr(mod, "__file__"):
             return False
 
+        mod_parts = modname.split(".")
+
         if modname in self.excludes:
             return False
 
         for app_modname in self.test_apps:
-            if modname.startswith(app_modname):
+            app_parts = app_modname.split(".")
+
+            if mod_parts[:len(app_parts)] == app_parts:
                 return True
 
         return False


### PR DESCRIPTION
I noticed that the include/exclude logic could match too many things because it compared module components. To use one example, we have a module named `project.core` which also caused things like `atom.core` to be excluded. This patch simply changes the logic to be prefix-based for inclusion and exact for exclusion - a more complete solution might have been making both exact with wildcard support but these semantics let me get the behaviour I needed.
