### PR TITLE
Prevent issues with TransactionTestCase

### DIFF
--- a/django_jenkins/runner.py
+++ b/django_jenkins/runner.py
@@ -10,7 +10,8 @@ from cStringIO import StringIO
 from unittest import _TextTestResult, TestResult
 from xml.dom.minidom import Document
 from django.conf import settings
-from django.test.simple import DjangoTestSuiteRunner, DjangoTestRunner
+from django.test import TestCase
+from django.test.simple import DjangoTestSuiteRunner, DjangoTestRunner, reorder_suite
 from django_jenkins import signals
 
 
@@ -328,7 +329,7 @@ class CITestSuiteRunner(DjangoTestSuiteRunner):
     def build_suite(self, test_labels, **kwargs):
         suite = unittest.TestSuite()
         signals.build_suite.send(sender=self, suite=suite)
-        return suite
+        return reorder_suite(suite, (TestCase,))
 
     def run_tests(self, test_labels, extra_tests=None, **kwargs):
         self.setup_test_environment()


### PR DESCRIPTION
Thanks for django-jenkins--it is very useful.

I spent a long time trying to debug an issue that my test suite worked using the standard Django test runner but failed when using the CITestSuiteRunner.  The issue turned out to be several TransactionTestCases that left the database in a dirty state.  My changeset reorders the test suite to match how DjangoTestSuiteRunner runs the test, thus at least making django-jenkins testing consistent with the Django test runner.

Commit Message:
Reorder the test suite to match the order when using the standard Django test suite runner.

Django, in django.test.simple.DjangoTestSuiteRunner.build_suite, reorders
the suite, so that instances of django.test.TestCase come before other types
of tests [1](https://code.djangoproject.com/changeset/9756).  This changeset causes the CITestSuiteRunner to mirror the reordering
behaviour.

In most cases the order is unimportant, but there are cases when using
django.test.TransactionTestCase that leaves data in the database after test
teardown.  If a standard TestCase, using the rollback speedup [1](https://code.djangoproject.com/changeset/9756), comes after
such a TransactionTestCase, the TestCase could unexpectedly run into this data.
While Django's leaving data is less than ideal, django-jenkins should
at least mirror the behaviour to prevent unexpected test failures that can
not be replicated when using the standard Django test runner.
