### PR TITLE
Added signals to customize addFailure, addSuccess and addError

### DIFF
--- a/django_jenkins/runner.py
+++ b/django_jenkins/runner.py
@@ -112,16 +112,19 @@ class _XMLTestResult(_TextTestResult):
 
     def addSuccess(self, test):
         "Called when a test executes successfully."
+        signals.test_add_success.send(sender=self, test=test)
         self._prepare_callback(_TestInfo(self, test), \
             self.successes, 'OK', '.')
 
     def addFailure(self, test, err):
         "Called when a test method fails."
+        signals.test_add_failure.send(sender=self, test=test, err=err)
         self._prepare_callback(_TestInfo(self, test, _TestInfo.FAILURE, err), \
             self.failures, 'FAIL', 'F')
 
     def addError(self, test, err):
         "Called when a test method raises an error."
+        signals.test_add_error.send(sender=self, test=test, err=err)
         self._prepare_callback(_TestInfo(self, test, _TestInfo.ERROR, err), \
             self.errors, 'ERROR', 'E')
 

--- a/django_jenkins/signals.py
+++ b/django_jenkins/signals.py
@@ -8,3 +8,8 @@ before_suite_run = Signal()
 after_suite_run = Signal()
 
 build_suite = Signal(providing_args=["suite"])
+
+test_add_failure = Signal(providing_args=['test', 'err'])
+test_add_error = Signal(providing_args=['test', 'err'])
+test_add_success = Signal(providing_args=['test'])
+


### PR DESCRIPTION
I want to customize addFailure to get a screenshot of failed test in selenium environment.

The unittest and django allow to customize these methods that would allow me to get the screenshot.

As the runner._XMLTestResult just overwrote the addFailure without call the super it remove that option.

As other points to customization were using signals I added a this as signals.
