### PR TITLE
csslint: generate valid XML when no files are found

### DIFF
--- a/django_jenkins/tasks/run_csslint.py
+++ b/django_jenkins/tasks/run_csslint.py
@@ -70,7 +70,7 @@ class Task(BaseTask):
 
             self.output.write(output)
         elif self.to_file:
-            self.output.write('<csslint></csslint')
+            self.output.write('<csslint></csslint>')
 
     def static_files_iterator(self):
         locations = get_apps_locations(self.test_labels, self.test_all)


### PR DESCRIPTION
Current it generates `<csslint></csslint` which causes the Jenkins Violations plugin to choke with an XML parse error
