### PR TITLE
Make tests/manage.py executable

### DIFF
--- a/tests/manage.py
+++ b/tests/manage.py
@@ -1,4 +1,4 @@
-# -*- coding: utf-8 -*-
+#!/usr/bin/env python
 import sys
 from os import path
 from django.core.management import execute_manager


### PR DESCRIPTION
It's executable in a fresh Django project, so it would be consistent if it were executable in the `tests` project too.
