### PR TITLE
This fixes #92

### DIFF
--- a/django_jenkins/runner.py
+++ b/django_jenkins/runner.py
@@ -14,7 +14,7 @@ from django.test import TestCase
 from django.test.simple import DjangoTestSuiteRunner, reorder_suite
 from django_jenkins import signals
 try:
-    from django.test.simple import TextTestRunner as TestRunner
+    from django.utils.unittest import TextTestRunner as TestRunner
 except ImportError:
     from django.test.simple import DjangoTestRunner as TestRunner
 


### PR DESCRIPTION
The import from django.utils.unittest will fail on Django 1.2, so
we handle the ImportError and instead use the test runner from
that point.
