### PR TITLE
Setting tests pep8 version to 1.2.

### DIFF
--- a/tests/requirements.pip
+++ b/tests/requirements.pip
@@ -2,7 +2,7 @@ django>=1.2
 pylint>=0.23
 coverage>=3.4
 pyflakes
-pep8
+pep8==1.2
 lettuce
 
 # development only


### PR DESCRIPTION
pep8 tasks doesn't work on the latest pep8 version (1.3), so setting the tests version to 1.2 (latest working version).
