### PR TITLE
create valid xml for empty csslint output

### DIFF
--- a/django_jenkins/tasks/run_csslint.py
+++ b/django_jenkins/tasks/run_csslint.py
@@ -81,7 +81,7 @@ class Task(BaseTask):
 
             self.output.write(output)
         elif self.to_file:
-            self.output.write('<csslint></csslint')
+            self.output.write('<?xml version="1.0" encoding="utf-8"?><lint></lint>')
 
     def static_files_iterator(self):
         locations = get_apps_locations(self.test_labels, self.test_all)


### PR DESCRIPTION
Updated run_csslint behavior when there are no css files to process: output valid xml with the <lint> tag that jenkins seems to want. Please review and see what you think. Thanks
