### PR TITLE
Allow reading local pep8 config_file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,5 +3,4 @@
 .coverage
 *.pyc
 reports
-
-
+*.egg-info/

--- a/django_jenkins/tasks/run_pep8.py
+++ b/django_jenkins/tasks/run_pep8.py
@@ -8,19 +8,6 @@ from django_jenkins.tasks import BaseTask, get_apps_locations
 
 
 class Task(BaseTask):
-    option_list = [make_option("--pep8-exclude",
-                               dest="pep8-exclude", default=pep8.DEFAULT_EXCLUDE + ",migrations",
-                               help="exclude files or directories which match these "
-                               "comma separated patterns (default: %s)" %
-                               pep8.DEFAULT_EXCLUDE),
-                   make_option("--pep8-select", dest="pep8-select",
-                               help="select errors and warnings (e.g. E,W6)"),
-                   make_option("--pep8-ignore", dest="pep8-ignore",
-                               help="skip errors and warnings (e.g. E4,W)"),
-                   make_option("--pep8-max-line-length", dest="pep8-max-line-length", type='int',
-                               help="set maximum allowed line length (default: %d)" % pep8.MAX_LINE_LENGTH),
-
-]
 
     def __init__(self, test_labels, options):
         super(Task, self).__init__(test_labels, options)
@@ -34,14 +21,6 @@ class Task(BaseTask):
         else:
             self.output = sys.stdout
 
-        self.pep8_options = ['--exclude=%s' % options['pep8-exclude']]
-        if options['pep8-select']:
-            self.pep8_options.append('--select=%s' % options['pep8-select'])
-        if options['pep8-ignore']:
-            self.pep8_options.append('--ignore=%s' % options['pep8-ignore'])
-        if options['pep8-max-line-length']:
-            self.pep8_options.append('--max-line-length=%s' % options['pep8-max-line-length'])
-
     def teardown_test_environment(self, **kwargs):
         locations = get_apps_locations(self.test_labels, self.test_all)
 
@@ -53,10 +32,11 @@ class Task(BaseTask):
                     return
                 sourceline = instance.line_offset + line_number
                 self.output.write('%s:%s:%s: %s\n' % (instance.filename, sourceline, offset+1, text))
-    
-        pep8style = pep8.StyleGuide(parse_argv=False, config_file=False, reporter=JenkinsReport)
+
+
+        pep8style = pep8.StyleGuide(parse_argv=False, config_file='.pep8', reporter=JenkinsReport)
 
         for location in locations:
             pep8style.input_dir(relpath(location))
-        
+
         self.output.close()


### PR DESCRIPTION
Read a `.pep8` file from `cwd`. This works by overriding `config_file` which is meant for user configurations, but we are forcibly not using the `~/.config/pep8` file anyways. This is also good by storing pep8 options with the django project in version control, and can specify arbitrary pep8 options without extra specialized command like options.
