### PR TITLE
pass pep8 options as dict (for pep8 1.3 StyleGuide)

### DIFF
--- a/django_jenkins/tasks/run_pep8.py
+++ b/django_jenkins/tasks/run_pep8.py
@@ -34,13 +34,13 @@ class Task(BaseTask):
         else:
             self.output = sys.stdout
 
-        self.pep8_options = ['--exclude=%s' % options['pep8-exclude']]
+        self.pep8_options = { 'exclude': options['pep8-exclude'].split(',') }
         if options['pep8-select']:
-            self.pep8_options.append('--select=%s' % options['pep8-select'])
+            self.pep8_options['select'] = options['pep8-select'].split(',')
         if options['pep8-ignore']:
-            self.pep8_options.append('--ignore=%s' % options['pep8-ignore'])
+            self.pep8_options['ignore'] = options['pep8-ignore'].split(',')
         if options['pep8-max-line-length']:
-            self.pep8_options.append('--max-line-length=%s' % options['pep8-max-line-length'])
+            self.pep8_options['max-line-length'] = options['pep8-max-line-length']
 
     def teardown_test_environment(self, **kwargs):
         locations = get_apps_locations(self.test_labels, self.test_all)
@@ -54,7 +54,7 @@ class Task(BaseTask):
                 sourceline = instance.line_offset + line_number
                 self.output.write('%s:%s:%s: %s\n' % (instance.filename, sourceline, offset+1, text))
     
-        pep8style = pep8.StyleGuide(parse_argv=False, config_file=False, reporter=JenkinsReport)
+        pep8style = pep8.StyleGuide(parse_argv=False, config_file=False, reporter=JenkinsReport, **self.pep8_options)
 
         for location in locations:
             pep8style.input_dir(relpath(location))


### PR DESCRIPTION
A simple change to pass the options to pep8 1.3. I had noticed that "migrations" wasn't getting excluded, so this fixes that and other option behavior. Let me know if you have any comments or requests.
- Steven
