### PR TITLE
Use absolute paths to fix empty JSLint report

### DIFF
--- a/django_jenkins/tasks/run_jslint.py
+++ b/django_jenkins/tasks/run_jslint.py
@@ -67,7 +67,7 @@ class Task(BaseTask):
 
         for path in self.static_files_iterator():
             jslint_output = check_output(
-                [self.interpreter, self.runner, self.implementation, relpath(path), fmt])
+                [self.interpreter, self.runner, self.implementation, path, fmt])
             self.output.write(jslint_output)
 
         if self.to_file:


### PR DESCRIPTION
With a relative path I got a blank page when trying to view violations in Jenkins. The same problem described by:

https://groups.google.com/forum/#!msg/jenkinsci-users/cUfZimHHXqs/orh2CLaOrHAJ

Some posts on the Internet suggest that relative paths used to work in Jenkins, however looking at the Jenkins code, there is nothing to resolve the path so only absolute ones will work now:

https://github.com/jenkinsci/violations-plugin/blob/master/src/main/java/hudson/plugins/violations/types/jslint/JsLintParser.java

fixAbsolutePath() only removes ".." in the path, it does not resolve a path relative to the workspace into an absolute one.
