### PR TITLE
switch from TestCase to LiveServerTestCase in lettuce_tests.py to better support liveserver option

### DIFF
--- a/django_jenkins/tasks/lettuce_tests.py
+++ b/django_jenkins/tasks/lettuce_tests.py
@@ -3,7 +3,7 @@ import os
 from optparse import make_option
 from django.conf import settings
 from django_jenkins.tasks import BaseTask
-from unittest import TestCase
+from django.test import LiveServerTestCase
 from lettuce.django import harvest_lettuces
 from lettuce import Runner
 from lettuce import registry
@@ -52,7 +52,7 @@ class Task(BaseTask):
         return suite
 
 
-class LettuceTestCase(TestCase):
+class LettuceTestCase(LiveServerTestCase):
     def __init__(self, runner, app_module, *args, **kwargs):
         super(LettuceTestCase, self).__init__(*args, **kwargs)
         self.runner = runner


### PR DESCRIPTION
Hi Mikhail,

what do you think about this change?

I did it, because I need to use lettuce with running server and it's not clear from the begging how to do it properly.
I have already read manual from lettuce and my tests work perfectly with "manage.py harvest", but running them through "manage.py lettuce" or "manage.py jenkins" always give me "Connection refused" exception in lettuce.xml report. Checked, but django server is newer started on this tests. Investigated how work "liveserver" and "lettuce-server" options, but non of them work as expected. When I set manualy database (sync and migrate) on disk (for test & developement we use sqlite), everything works fine, but when no DB is set, and we run "manage.py lettuce --lettuce-server", django server is using DB from settings.py, not the :memory: as the rest of tests do.

I don't want our tests to use DB from settings, because I don't want to set it up each time test are run and which is more important, I don't want "./manage.py lettuce/jenkins" operate on any already existing DB.

After this two small changes to lettuce_tests.py, I can run:

> python manage.py lettuce --liveserver=127.0.0.1:7000

server is started, tests work as expected.

Regards,
Piotr
