### PR TITLE
Adds encoding declaration to setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,6 @@
 #!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
 import codecs
 from os import path
 from setuptools import setup


### PR DESCRIPTION
As a non-ascii character was added to README.rst in 86708ee8803acfde38 i guess this file needs an encoding declaration now to prevent UnicodeEncodeError.
