### PR TITLE
Use correct TestCase class

### DIFF
--- a/django_jenkins/runner.py
+++ b/django_jenkins/runner.py
@@ -7,7 +7,8 @@ from xml.sax.saxutils import XMLGenerator
 from xml.sax.xmlreader import AttributesImpl
 from django.conf import settings
 from django.test.simple import DjangoTestSuiteRunner, reorder_suite
-from django.utils.unittest import TestSuite, TestCase, TextTestResult, TextTestRunner
+from django.test.testcases import TestCase
+from django.utils.unittest import TestSuite, TextTestResult, TextTestRunner
 from django_jenkins import signals
 from django_jenkins.functions import total_seconds
 


### PR DESCRIPTION
Django (at least 1.4.x) defines two distinct TestCase classes. The one passed to reorder_suite call in CITestSuiteRunner is the wrong one, which may cause TransactionTestCase instances to be executed before TestCase instances (leaving junk in database).
