### PR TITLE
Python3 compliance and flake8 command 

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -140,6 +140,15 @@ Here is the list of tasks prebuild with django-jenkins
 
 .. _Pyflakes: http://pypi.python.org/pypi/pyflakes
 
+- ``django_jenkins.tasks.run_flake8``
+
+  Runs flake8 tool over selected Django apps.
+  Creates Pylint compatible report for Jenkins.
+
+  You should have flake8_ python package installed to run this task.
+
+.. _flake8: http://pypi.python.org/pypi/flake8
+
 - ``django_jenkins.tasks.run_sloccount``
 
   Runs SLOCCount_ tool over selected Django apps.

--- a/django_jenkins/management/commands/flake8.py
+++ b/django_jenkins/management/commands/flake8.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+from optparse import make_option
+from django_jenkins.management.commands import TaskListCommand
+
+
+class Command(TaskListCommand):
+    help = "Run flake8 over project apps"
+    args = '[appname ...]'
+    option_list = TaskListCommand.option_list + (
+        make_option(
+            '--flake8-file-output',
+            action='store_true',
+            dest='flake8_file_output',
+            default=False,
+            help='Store flake8 report in file'),
+    )
+
+    def get_task_list(self):
+        return ('django_jenkins.tasks.run_flake8',)


### PR DESCRIPTION
run_flake8 task should now be python3 compliant.
README.rst now has a short section on the run_flake8 task.
flake8 can be run as a management command.
