### PR TITLE
Parameters for setting dirname with static files for jsHint and cssLint

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,5 +8,6 @@ reports
 .tox
 django_jenkins.egg-info/
 MANIFEST
+.idea/*
 
 

--- a/django_jenkins/tasks/run_csslint.py
+++ b/django_jenkins/tasks/run_csslint.py
@@ -28,7 +28,10 @@ class Task(BaseTask):
                    help="Do not ignore .min.css files"),
        make_option("--csslint-exclude",
                    dest="csslint_exclude", default="",
-              help="Exclude patterns")]
+              help="Exclude patterns"),
+       make_option("--csslint-static-dirname",
+                   dest="csslint_static-dirname", default="static",
+                   help="Name of dir with css static files")]
 
     def __init__(self, test_labels, options):
         super(Task, self).__init__(test_labels, options)
@@ -69,6 +72,7 @@ class Task(BaseTask):
             self.output = sys.stdout
 
         self.exclude = options['csslint_exclude'].split(',')
+        self.static_dirname = options.get('csslint_static-dirname', 'static')
 
     def teardown_test_environment(self, **kwargs):
         files = [path for path in self.static_files_iterator()]
@@ -132,7 +136,7 @@ class Task(BaseTask):
             # scan apps directories for static folders
             for location in locations:
                 for dirpath, dirnames, filenames in \
-                                os.walk(os.path.join(location, 'static')):
+                                os.walk(os.path.join(location, self.static_dirname)):
                     for filename in filenames:
                         path = os.path.join(dirpath, filename)
                         if filename.endswith('.css') and \

--- a/django_jenkins/tasks/run_jshint.py
+++ b/django_jenkins/tasks/run_jshint.py
@@ -22,7 +22,10 @@ class Task(BaseTask):
                        help="Do not ignore .min.js files"),
            make_option("--jshint-exclude",
                        dest="jshint_exclude", default="",
-                       help="Exclude patterns")]
+                       help="Exclude patterns"),
+           make_option("--jshint-static-dirname",
+                       dest="jshint_static-dirname", default="static",
+                       help="Name of dir with js static files")]
 
     def __init__(self, test_labels, options):
         super(Task, self).__init__(test_labels, options)
@@ -41,6 +44,7 @@ class Task(BaseTask):
             self.output = sys.stdout
 
         self.exclude = options['jshint_exclude'].split(',')
+        self.static_dirname = options.get('jshint_static-dirname', 'static')
 
     def teardown_test_environment(self, **kwargs):
         files = [path for path in self.static_files_iterator()]
@@ -97,7 +101,7 @@ class Task(BaseTask):
             # scan apps directories for static folders
             for location in locations:
                 for dirpath, dirnames, filenames in \
-                        os.walk(os.path.join(location, 'static')):
+                        os.walk(os.path.join(location, self.static_dirname)):
                     for filename in filenames:
                         path = os.path.join(dirpath, filename)
                         if filename.endswith('.js') and \


### PR DESCRIPTION
I have added 2 parameters to set directory with static files: --jshint-static-dirname and --csslint-static-dirname. In our projects we use your library but js and css files we store at dir named 'media' not 'static'.
