### PR TITLE
Instruct pylint to ignore unfound members of WSGIRequest

### DIFF
--- a/django_jenkins/tasks/pylint.rc
+++ b/django_jenkins/tasks/pylint.rc
@@ -38,7 +38,7 @@ ignore-mixin-members=yes
 
 # List of classes names for which member attributes should not be checked
 # (useful for classes with attributes dynamically set).
-ignored-classes=SQLObject
+ignored-classes=SQLObject,WSGIRequest
 
 # When zope mode is activated, add a predefined set of Zope acquired attributes
 # to generated-members.


### PR DESCRIPTION
Pylint throws a lot of warnings of unfound members on my testcases, as wsgirequest's members could not be inspected.
