### PR TITLE
Fix ASCII encoding issue for CSS lint

### DIFF
--- a/django_jenkins/tasks/run_csslint.py
+++ b/django_jenkins/tasks/run_csslint.py
@@ -3,6 +3,7 @@ import os
 import subprocess
 import sys
 import fnmatch
+import codecs
 from optparse import make_option
 from django.conf import settings
 from django_jenkins.functions import (CalledProcessError,
@@ -64,7 +65,7 @@ class Task(BaseTask):
             output_dir = options['output_dir']
             if not os.path.exists(output_dir):
                 os.makedirs(output_dir)
-            self.output = open(os.path.join(output_dir, 'csslint.report'), 'w')
+            self.output = codecs.open(os.path.join(output_dir, 'csslint.report'), 'w', 'utf-8')
         else:
             self.output = sys.stdout
 


### PR DESCRIPTION
This fixes #147 in the same way that issue #129 was fixed for JS hint. This problem was causing errors during tests and failing to write output.
