### PR TITLE
Update README.rst

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -98,7 +98,7 @@ Here is the list of tasks prebuild with django-jenkins
 
   Produces `XML coverage report <http://nedbatchelder.com/code/coverage/sample_html/>`__ for Jenkins
 
-  Task-specific settings: ``COVERAGE_RCFILE``, ``COVERAGE_REPORT_HTML_OUTPUT_DIR``, ``COVERAGE_MEASURE_BRANCH``, ``COVERAGE_EXCLUDES``, ``COVERAGE_WITH_MIGRATIONS``
+  Task-specific settings: ``COVERAGE_RCFILE``, ``COVERAGE_REPORT_HTML_OUTPUT_DIR``, ``COVERAGE_MEASURE_BRANCH``, ``COVERAGE_EXCLUDES``, ``COVERAGE_WITH_MIGRATIONS``, ``COVERAGE_EXCLUDES_FOLDERS``
 
 - ``django_jenkins.tasks.django_tests``
 


### PR DESCRIPTION
Extended the task-specific settings of tasks.with_coverage to include COVERAGE_EXCLUDES_FOLDERS (https://github.com/kmmbvnr/django-jenkins/blob/master/django_jenkins/tasks/with_coverage.py#L63-L66)
