### PR TITLE
remove deprecation warning from pylint 1.0

### DIFF
--- a/django_jenkins/tasks/run_pylint.py
+++ b/django_jenkins/tasks/run_pylint.py
@@ -7,7 +7,10 @@ from django.conf import settings
 from django_jenkins.tasks import BaseTask, get_apps_under_test
 
 from pylint import lint
-from pylint.reporters.text import ParseableTextReporter
+from pylint.reporters.text import TextReporter
+
+
+OUTPUT_FORMAT = '{path}:{line}: [{msg_id}({symbol}), {obj}] {msg}'
 
 
 class Task(BaseTask):
@@ -41,7 +44,8 @@ class Task(BaseTask):
             args += ['--errors-only']
         args += get_apps_under_test(self.test_labels, self.test_all)
 
-        lint.Run(args, reporter=ParseableTextReporter(output=self.output),
+        TextReporter.line_format = OUTPUT_FORMAT
+        lint.Run(args, reporter=TextReporter(output=self.output),
                                                       exit=False)
 
         return True


### PR DESCRIPTION
In pylint > 1.0, there is a warning from using ParseableTextReporter. This will use the main TextReporter class, with the line_format set to be the same as the old ParseableTextReporter.

https://bitbucket.org/logilab/pylint/src/bdebb394a37ac7e18328a5f49124f44e8e11e82d/reporters/text.py?at=default#cl-68
