### PR TITLE
Fixed jshint exclude patterns to match full path

### DIFF
--- a/django_jenkins/tasks/run_jshint.py
+++ b/django_jenkins/tasks/run_jshint.py
@@ -93,9 +93,11 @@ class Task(BaseTask):
             from django.contrib.staticfiles import finders
 
             for finder in finders.get_finders():
-                for path, storage in finder.list(self.exclude):
+                for path, storage in finder.list(None):
                     path = os.path.join(storage.location, path)
-                    if path.endswith('.js') and in_tested_locations(path):
+                    if path.endswith('.js') and \
+                            in_tested_locations(path) and not \
+                                is_excluded(path):
                         yield path
         else:
             # scan apps directories for static folders


### PR DESCRIPTION
Django static file finders only consider the file name when looking for ignore patterns. Because of that you cannot use patterns like '*/js/lib/* to exclude all files in the js/lib static folder. This change fixes that by getting all static files from the static file finder then applying the exclude pattern to the full path.
