### PR TITLE
junit.xml can't be written if sysout contains non-ASCII text

### DIFF
--- a/django_jenkins/runner.py
+++ b/django_jenkins/runner.py
@@ -5,6 +5,7 @@ import time
 
 from xml.etree import ElementTree as ET
 from django.conf import settings
+from django.utils.encoding import smart_text
 from django.test.testcases import TestCase
 from django.utils.unittest import TextTestResult, TextTestRunner
 
@@ -85,12 +86,12 @@ class EXMLTestResult(TextTestResult):
             output = sys.stdout.getvalue()
             if output:
                 sysout = ET.SubElement(self.testcase, 'system-out')
-                sysout.text = output.decode('UTF-8', 'ignore')
+                sysout.text = smart_text(output, errors='ignore')
 
             error = sys.stderr.getvalue()
             if error:
                 syserr = ET.SubElement(self.testcase, 'system-err')
-                syserr.text = error.decode('UTF-8', 'ignore')
+                syserr.text = smart_text(error, errors='ignore')
 
         super(EXMLTestResult, self).stopTest(test)
 

--- a/tests/test_app/tests.py
+++ b/tests/test_app/tests.py
@@ -21,6 +21,15 @@ class SaintyChecks(TestCase):
     def test_is_skipped(self):
         print("This test should be skipped")
 
+    def test_junit_xml_with_utf8_stdout_and_stderr(self):
+        sys.stdout.write('\xc4\x85')
+        sys.stderr.write('\xc4\x85')
+
+    def test_junit_xml_with_invalid_stdout_and_stderr_encoding(self):
+        sys.stdout.write('\xc4')
+        sys.stderr.write('\xc4')
+
+
     #def test_failure(self):
     #    raise Exception("Ups, should be disabled")
 


### PR DESCRIPTION
Thanks for the tip about the django helper function. Trying this again with a version that works on python 3.

We have some tests that are emitting non-ASCII characters to stdout and stderr. When the junit.xml report is being written out the following error occurs:

```
Traceback (most recent call last):
  File "manage.py", line 9, in <module>
    execute_from_command_line(sys.argv)
  File "/Users/arcane/.virtualenvs/rescale/lib/python2.7/site-packages/django/core/management/__init__.py", line 399, in execute_from_command_line
    utility.execute()
  File "/Users/arcane/.virtualenvs/rescale/lib/python2.7/site-packages/django/core/management/__init__.py", line 392, in execute
    self.fetch_command(subcommand).run_from_argv(self.argv)
  File "/Users/arcane/.virtualenvs/rescale/lib/python2.7/site-packages/django/core/management/base.py", line 242, in run_from_argv
    self.execute(*args, **options.__dict__)
  File "/Users/arcane/.virtualenvs/rescale/lib/python2.7/site-packages/django/core/management/base.py", line 285, in execute
    output = self.handle(*args, **options)
  File "/Users/arcane/.virtualenvs/rescale/src/django-jenkins/django_jenkins/management/commands/__init__.py", line 93, in handle
    if test_runner.run_tests(test_labels):
  File "/Users/arcane/.virtualenvs/rescale/lib/python2.7/site-packages/django/test/runner.py", line 146, in run_tests
    result = self.run_suite(suite)
  File "/Users/arcane/.virtualenvs/rescale/src/django-jenkins/django_jenkins/runner.py", line 171, in run_suite
    result.dump_xml(self.output_dir)
  File "/Users/arcane/.virtualenvs/rescale/src/django-jenkins/django_jenkins/runner.py", line 132, in dump_xml
    output.write(os.path.join(output_dir, 'junit.xml'), encoding="utf-8")
  File "/System/Library/Frameworks/Python.framework/Versions/2.7/lib/python2.7/xml/etree/ElementTree.py", line 820, in write
    serialize(write, self._root, encoding, qnames, namespaces)
  File "/System/Library/Frameworks/Python.framework/Versions/2.7/lib/python2.7/xml/etree/ElementTree.py", line 939, in _serialize_xml
    _serialize_xml(write, e, encoding, qnames, None)
  File "/System/Library/Frameworks/Python.framework/Versions/2.7/lib/python2.7/xml/etree/ElementTree.py", line 939, in _serialize_xml
    _serialize_xml(write, e, encoding, qnames, None)
  File "/System/Library/Frameworks/Python.framework/Versions/2.7/lib/python2.7/xml/etree/ElementTree.py", line 937, in _serialize_xml
    write(_escape_cdata(text, encoding))
  File "/System/Library/Frameworks/Python.framework/Versions/2.7/lib/python2.7/xml/etree/ElementTree.py", line 1073, in _escape_cdata
    return text.encode(encoding, "xmlcharrefreplace")
UnicodeDecodeError: 'ascii' codec can't decode byte 0xc3 in position 30883: ordinal not in range(128)
```

Changed the EXMLTestResult to make an attempt to convert stdout and stderr to unicode using utf-8 and otherwise ignore the character which is preferable to having the entire task fail.
