### PR TITLE
Fix skipping migrations in run_pyflakes task.

### DIFF
--- a/django_jenkins/tasks/run_pyflakes.py
+++ b/django_jenkins/tasks/run_pyflakes.py
@@ -46,7 +46,7 @@ class Task(BaseTask):
                     for dirpath, dirnames, filenames in \
                                         os.walk(relpath(location)):
                         if not self.with_migrations and \
-                                (os.sep + 'migrations' + os.sep) in dirpath:
+                                dirpath.endswith(os.sep + 'migrations'):
                             continue
                         for filename in filenames:
                             if filename.endswith('.py'):


### PR DESCRIPTION
Runner does not skip migration files, because dirpath for directories with migrations is "my_app/migrations".
