### PR TITLE
Support JSHint exlude by filepath patterns

### DIFF
--- a/django_jenkins/tasks/run_jshint.py
+++ b/django_jenkins/tasks/run_jshint.py
@@ -93,10 +93,11 @@ class Task(BaseTask):
             from django.contrib.staticfiles import finders
 
             for finder in finders.get_finders():
-                for path, storage in finder.list(self.exclude):
-                    path = os.path.join(storage.location, path)
-                    if path.endswith('.js') and in_tested_locations(path):
-                        yield path
+                for path, storage in finder.list(None):
+                    if not is_excluded(path):
+                        path = os.path.join(storage.location, path)
+                        if path.endswith('.js') and in_tested_locations(path):
+                            yield path
         else:
             # scan apps directories for static folders
             for location in locations:


### PR DESCRIPTION
For example I have a unminified file `irk/static/fileupload/js/lib/app.js`.
But I don't want to include that file into statistics because it is a js library. I trying to exlude such files with pattern `--jshint-exclude=*/lib/*`
But it is not take any effect, becase `finder.list(self.exclude)` checks only filnames without path.
There is my solution for that situation.
