### PR TITLE
Allow additional exclusion patterns for PEP8 task

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -95,7 +95,15 @@ Here is the reporters prebuild with django-jenkins
 
   You should have pep8_ python package (>=1.3) installed to run this task.
 
-  Task-specific settings: ``PEP8_RCFILE``
+  Task-specific settings: ``PEP8_RCFILE``, ``PEP8_EXCLUDES``
+  - ``PEP8_EXCLUDES``
+  
+      Accepts a list of additional file exclusion patterns to add to the pep8 task.
+  
+      Default Value::
+      
+      PEP8_EXCLUDES = ()
+
 
 .. _pep8: http://pypi.python.org/pypi/pep8
 

--- a/django_jenkins/tasks/run_pep8.py
+++ b/django_jenkins/tasks/run_pep8.py
@@ -3,12 +3,15 @@ import pep8
 from optparse import make_option
 from django.conf import settings
 
+DEFAULT_PEP8_EXCLUDES = ('south_migrations',)
 
 class Reporter(object):
     option_list = (
         make_option("--pep8-exclude",
                     dest="pep8-exclude",
-                    default=pep8.DEFAULT_EXCLUDE + ",south_migrations",
+                    default=pep8.DEFAULT_EXCLUDE + ",".join(
+                        DEFAULT_PEP8_EXCLUDES + tuple(getattr(settings, 'PEP8_EXCLUDES', ()))
+                    ),
                     help="exclude files or directories which match these "
                     "comma separated patterns (default: %s)" %
                     pep8.DEFAULT_EXCLUDE),


### PR DESCRIPTION
I found that the pep8-exclude option overrides exclusions in the pep8.rc file. 
- The hardcoded south_migrations exclusion in `run_pep8.py` overrides settings that are added to pep8.rc
- Added `PEP8_EXCLUDES` option which allows additional exclusions to be added to the pep8 task.
- Exclusions can be either list or tuple format (it coerces to a tuple).
