### PR TITLE
May resolve issue #231

### DIFF
--- a/django_jenkins/management/commands/jenkins.py
+++ b/django_jenkins/management/commands/jenkins.py
@@ -143,7 +143,7 @@ class Command(TestCommand):
             # django 1.6
             from django.utils.importlib import import_module
             for test_label in test_labels:
-                models_module = get_app(test_label.split('.')[-1])
+                models_module = import_module(test_label)
                 locations.append(os.path.dirname(models_module.__file__))
 
         return locations


### PR DESCRIPTION
https://github.com/kmmbvnr/django-jenkins/issues/231

The assumption that the models path is the same as the app path is incorrect when there is models package instead of just a file.

Line 131 was changed so that ./manage.py jenkins myapp.test.ViewTests.specific_test would run without problems. I would understand if this wasn't desired for other people but it fit my use case.
