### PR TITLE
Ignore django migrations

### DIFF
--- a/django_jenkins/tasks/run_pep8.py
+++ b/django_jenkins/tasks/run_pep8.py
@@ -38,7 +38,7 @@ class Reporter(object):
 
         if options['pep8-exclude'] is None:
             if pep8_options['config_file'] is None:
-                pep8_options = {'exclude': (pep8.DEFAULT_EXCLUDE + ",south_migrations").split(',')}
+                pep8_options = {'exclude': (pep8.DEFAULT_EXCLUDE + ",migrations,south_migrations").split(',')}
         else:
             pep8_options = {'exclude': options['pep8-exclude'].split(',')}
         if options['pep8-select']:


### PR DESCRIPTION
Since they are auto-generated there should be no need to run pep8 on migrations, right? Besides, migrations created in South < 1.0 don't pass pep8, so this change fixes a lot of meaningless test failures.
#244
