### PR TITLE
changed: dependency patch versions set to latest

### DIFF
--- a/django_jenkins/tasks/with_coverage.py
+++ b/django_jenkins/tasks/with_coverage.py
@@ -15,7 +15,7 @@ def default_coverage_config():
 class CoverageReporter(object):
     def __init__(self):
         try:
-            from coverage.control import coverage
+            from coverage import coverage
         except ImportError:
             raise ImportError('coverage is not installed')
         else:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
-django==1.7
-pylint==1.3.1
-coverage==3.7.1
-pyflakes==0.8.1
-pep8==1.5.7
-selenium==2.43.0
-flake8==2.2.3
+django>=1.7,<1.8
+pylint>=1.3,<1.4
+coverage>=3.7,<3.8
+pyflakes>=0.8,<0.9
+pep8>=1.5,<1.6
+selenium>=2.43,<2.44
+flake8>=2.2,<2.3

--- a/tox.ini
+++ b/tox.ini
@@ -13,8 +13,8 @@ deps = -r{toxinidir}/requirements.txt
 # minimal support configuration
 [testenv:omega]
 basepython = python2.6
-deps = django==1.6.7  # rq.filter: >=1.6,<1.7
-       pylint==1.3.1
+deps = django>=1.6,<1.7
+       pylint>=1.3,<1.4
        coverage
        pyflakes
        pep8
@@ -26,7 +26,7 @@ deps = django==1.6.7  # rq.filter: >=1.6,<1.7
 [testenv:beta]
 basepython = python3.3
 deps = https://github.com/django/django/archive/1.7c2.zip
-       pylint==1.2.1
+       pylint>=1.2,<1.3
        coverage
        pyflakes
        pep8


### PR DESCRIPTION
Making a push to set dependency requirements fixed to minor version, not patch.

On a side note, what about using travis-ci.org and saucelabs.com?

http://docs.travis-ci.com/user/gui-and-headless-browsers/
https://saucelabs.com/opensauce
