### PR TITLE
EXMLTestResult: enable non-ascii tracebacks

### DIFF
--- a/django_jenkins/runner.py
+++ b/django_jenkins/runner.py
@@ -100,7 +100,7 @@ class EXMLTestResult(TextTestResult):
         tb_str = self._exc_info_to_string(err, test)
         test_result.set('type', '%s.%s' % (exc_class.__module__, exc_class.__name__))
         test_result.set('message', smart_text(exc_value))
-        test_result.text = tb_str
+        test_result.text = smart_text(tb_str)
 
     def dump_xml(self, output_dir):
         """


### PR DESCRIPTION
also contains a test for this element's message attribute, which was
addressed in commit 58d6d5539cfc5c8b8fa1ffade10bcd8917d807bc

Fixes issue #253.

Writing test cases for a test runner is tricky, but I think these do okay.
