### PR TITLE
upgrade deprecated jslint reporting

### DIFF
--- a/django_jenkins/tasks/run_jshint.py
+++ b/django_jenkins/tasks/run_jshint.py
@@ -22,7 +22,7 @@ class Reporter(object):
                                   extension='.js',
                                   ignore_patterns=options['jshint_exclude'].split(',')))
 
-        cmd = ['jshint', '--jslint-reporter'] + files
+        cmd = ['jshint', '--reporter=jslint'] + files
 
         process = subprocess.Popen(cmd, stdout=subprocess.PIPE)
         jshint_output, err = process.communicate()


### PR DESCRIPTION
The current jshint usage is deprecated, this is the new recommended usage
