### PR TITLE
Support Django 1.5 when django-discover-runner is installed.

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,3 +1,7 @@
+0.16.5 2015-02-05
+~~~~~~~~~~~~~~~~~
+* Support Django 1.5 when django-discover-runner is installed. (jsaz)
+
 0.16.4 2014-12-15
 ~~~~~~~~~~~~~~~~~
 

--- a/README.rst
+++ b/README.rst
@@ -29,6 +29,10 @@ Installation for Python 3::
 
     Works out of the box
 
+For Django 1.5, install this first::
+
+    $ pip install django-discover-runner
+
 
 Usage
 -----
@@ -136,6 +140,9 @@ Here is the reporters prebuild with django-jenkins
 
 Changelog
 ---------
+0.16.5 2015-02-05
+~~~~~~~~~~~~~~~~~
+* Support Django 1.5 when django-discover-runner is installed. (jsaz)
 
 0.16.4 2014-12-15
 ~~~~~~~~~~~~~~~~~

--- a/django_jenkins/runner.py
+++ b/django_jenkins/runner.py
@@ -5,9 +5,13 @@ import time
 from xml.etree import ElementTree as ET
 
 from django.conf import settings
-from django.test.runner import DiscoverRunner
 from django.utils.encoding import smart_text
 from django.utils.unittest import TextTestResult, TextTestRunner
+
+try:
+    from django.test.runner import DiscoverRunner
+except ImportError:
+    from discover_runner import DiscoverRunner
 
 
 class EXMLTestResult(TextTestResult):

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ read = lambda filepath: codecs.open(filepath, 'r', 'utf-8').read()
 
 setup(
     name='django-jenkins',
-    version='0.16.4',
+    version='0.16.5',
     author='Mikhail Podgurskiy',
     author_email='kmmbvnr@gmail.com',
     description='Plug and play continuous integration with django and jenkins',
@@ -36,7 +36,7 @@ setup(
         'Topic :: Software Development :: Testing'
     ],
     install_requires=[
-        'Django>=1.6',
+        'Django>=1.5',
     ],
     packages=['django_jenkins', 'django_jenkins.management',
               'django_jenkins.tasks', 'django_jenkins.management.commands'],


### PR DESCRIPTION
I'm stuck on Django 1.5 for a while. This quick change allows me to use your excellent app until I can upgrade to Django 1.6.