### PR TITLE
Django 1.8

### DIFF
--- a/django_jenkins/management/commands/jenkins.py
+++ b/django_jenkins/management/commands/jenkins.py
@@ -1,11 +1,11 @@
 import os
 import sys
 import warnings
+from importlib import import_module
 from optparse import OptionParser, make_option
 
 from django.conf import settings
 from django.core.management.commands.test import Command as TestCommand
-from django.utils.importlib import import_module
 
 from django_jenkins.runner import CITestSuiteRunner
 
@@ -171,7 +171,7 @@ class Command(TestCommand):
                     warnings.warn('No app found for test: {0}'.format(test_label))
         except ImportError:
             # django 1.6
-            from django.utils.importlib import import_module
+            from importlib import import_module
 
             def get_containing_app(object_name):
                 candidates = []

--- a/django_jenkins/management/commands/jenkins.py
+++ b/django_jenkins/management/commands/jenkins.py
@@ -49,7 +49,25 @@ class Command(TestCommand):
                     help="Module name to exclude"),
         make_option("--project-apps-tests", action="store_true",
                     default=False, dest="project_apps_tests",
-                    help="Take tests only from project apps")
+                    help="Take tests only from project apps"),
+
+        # Required by Django 1.8 if create_parser overrided
+        make_option('-v', '--verbosity', action='store', dest='verbosity', default='1',
+                    type='choice', choices=['0', '1', '2', '3'],
+                    help='Verbosity level; 0=minimal output, 1=normal output, 2=verbose output, 3=very verbose output'),
+        make_option('--settings',
+                    help=(
+                        'The Python path to a settings module, e.g. '
+                        '"myproject.settings.main". If this isn\'t provided, the '
+                        'DJANGO_SETTINGS_MODULE environment variable will be used.'
+                    ),
+        ),
+        make_option('--pythonpath',
+                    help='A directory to add to the Python path, e.g. "/home/djangoprojects/myproject".'),
+        make_option('--traceback', action='store_true',
+                    help='Raise on CommandError exceptions'),
+        make_option('--no-color', action='store_true', dest='no_color', default=False,
+                    help="Don't colorize the command output."),
     )
 
     def __init__(self):

--- a/django_jenkins/runner.py
+++ b/django_jenkins/runner.py
@@ -2,12 +2,12 @@ import os
 import sys
 import time
 
+from unittest import TextTestResult, TextTestRunner
 from xml.etree import ElementTree as ET
 
 from django.conf import settings
 from django.test.runner import DiscoverRunner
 from django.utils.encoding import smart_text
-from django.utils.unittest import TextTestResult, TextTestRunner
 
 
 class EXMLTestResult(TextTestResult):

--- a/django_jenkins/tasks/with_coverage.py
+++ b/django_jenkins/tasks/with_coverage.py
@@ -1,8 +1,8 @@
 import warnings
 import os
 import sys
+from importlib import import_module
 from django.conf import settings
-from django.utils.importlib import import_module
 
 
 def default_coverage_config():

--- a/setup.py
+++ b/setup.py
@@ -8,6 +8,15 @@ from setuptools import setup
 
 read = lambda filepath: codecs.open(filepath, 'r', 'utf-8').read()
 
+install_requires=[
+    'Django>=1.6',
+]
+
+# Needed for Python <2.7
+try:
+    import importlib
+except ImportError:
+    install_requires.append('importlib')
 
 setup(
     name='django-jenkins',
@@ -35,9 +44,7 @@ setup(
         'Topic :: Software Development :: Libraries :: Python Modules',
         'Topic :: Software Development :: Testing'
     ],
-    install_requires=[
-        'Django>=1.6',
-    ],
+    install_requires=install_requires,
     packages=['django_jenkins', 'django_jenkins.management',
               'django_jenkins.tasks', 'django_jenkins.management.commands'],
     package_data={'django_jenkins': ['tasks/pylint.rc']},

--- a/setup.py
+++ b/setup.py
@@ -15,8 +15,9 @@ install_requires=[
 # Needed for Python <2.7
 try:
     import importlib
+    import unittest
 except ImportError:
-    install_requires.append('importlib')
+    install_requires.append(['importlib', 'unittest'])
 
 setup(
     name='django-jenkins',

--- a/tests/test_app/tests.py
+++ b/tests/test_app/tests.py
@@ -1,11 +1,12 @@
 # -*- coding: utf-8 -*-
 import io
 import sys
+
+from unittest import skip
 from xml.etree import ElementTree as ET
 
 from django.core import mail
 from django.test import TestCase
-from django.utils.unittest import skip
 from django.test import LiveServerTestCase
 from selenium.webdriver.chrome.webdriver import WebDriver
 


### PR DESCRIPTION
Fixes the command arguments in `jenkins` command and deprecation warnings.

The Django command arguments were changed in Django 1.8 from optparse to argcmd. Django 1.8 handles backwards compatibility in the `create_parser` method which is overridden in django-jenkins in `jenkins.py`.