### PR TITLE
Replaced optparse by argparse to avoid casting error on python3.4 & django 1.8

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,3 +1,7 @@
+0.16.5 2014-04-03 (NON OFFICIAL)
+~~~~~~~~~~~~~~~~~
+* Added compatibility for python3.4 and Django 1.8 by using argparse instead of optparse (see https://docs.djangoproject.com/en/1.8/releases/1.8/#custom-test-management-command-arguments-through-test-runner)
+
 0.16.4 2014-12-15
 ~~~~~~~~~~~~~~~~~
 

--- a/django_jenkins/management/commands/jenkins.py
+++ b/django_jenkins/management/commands/jenkins.py
@@ -71,22 +71,6 @@ class Command(TestCommand):
                         default=False, dest="project_apps_tests",
                         help="Take tests only from project apps")
 
-
-    def create_parser(self, prog_name, subcommand):
-        test_runner_class = get_runner(settings, self.test_runner)
-        options = self.option_list + getattr(
-            test_runner_class, 'option_list', ())
-
-        for task in self.tasks:
-            options += tuple(option for option in getattr(task, 'option_list', ())
-                             if all(option._long_opts[0] != existing._long_opts[0]
-                                    for existing in options))
-
-        return OptionParser(prog=prog_name,
-                            usage=self.usage(subcommand),
-                            version=self.get_version(),
-                            option_list=options)
-
     def handle(self, *test_labels, **options):
         TestRunner = get_runner(settings, options.get('testrunner'))
         options['verbosity'] = int(options.get('verbosity'))

--- a/django_jenkins/management/commands/jenkins.py
+++ b/django_jenkins/management/commands/jenkins.py
@@ -70,6 +70,11 @@ class Command(TestCommand):
         parser.add_argument("--project-apps-tests", action="store_true",
                         default=False, dest="project_apps_tests",
                         help="Take tests only from project apps")
+        for task in self.tasks:
+            try:
+                task.add_arguments(parser)
+            except AttributeError:
+                pass
 
     def handle(self, *test_labels, **options):
         TestRunner = get_runner(settings, options.get('testrunner'))

--- a/django_jenkins/management/commands/jenkins.py
+++ b/django_jenkins/management/commands/jenkins.py
@@ -26,49 +26,6 @@ def get_runner(settings, test_runner_class=None):
 
 
 class Command(TestCommand):
-    option_list = TestCommand.option_list + (
-        make_option('--output-dir', dest='output_dir', default="reports",
-                    help='Report files directory'),
-        make_option("--enable-coverage",
-                    action="store_true", default=False,
-                    help="Measure code coverage"),
-        make_option('--debug', action='store_true',
-                    dest='debug', default=False,
-                    help='Do not intercept stdout and stderr, friendly for console debuggers'),
-        make_option("--coverage-rcfile",
-                    dest="coverage_rcfile",
-                    default="",
-                    help="Specify configuration file."),
-        make_option("--coverage-html-report",
-                    dest="coverage_html_report_dir",
-                    default="",
-                    help="Directory to which HTML coverage report should be"
-                    " written. If not specified, no report is generated."),
-        make_option("--coverage-exclude", action="append",
-                    default=[], dest="coverage_excludes",
-                    help="Module name to exclude"),
-        make_option("--project-apps-tests", action="store_true",
-                    default=False, dest="project_apps_tests",
-                    help="Take tests only from project apps"),
-
-        # Required by Django 1.8 if create_parser overrided
-        make_option('-v', '--verbosity', action='store', dest='verbosity', default='1',
-                    type='choice', choices=['0', '1', '2', '3'],
-                    help='Verbosity level; 0=minimal output, 1=normal output, 2=verbose output, 3=very verbose output'),
-        make_option('--settings',
-                    help=(
-                        'The Python path to a settings module, e.g. '
-                        '"myproject.settings.main". If this isn\'t provided, the '
-                        'DJANGO_SETTINGS_MODULE environment variable will be used.'
-                    ),
-        ),
-        make_option('--pythonpath',
-                    help='A directory to add to the Python path, e.g. "/home/djangoprojects/myproject".'),
-        make_option('--traceback', action='store_true',
-                    help='Raise on CommandError exceptions'),
-        make_option('--no-color', action='store_true', dest='no_color', default=False,
-                    help="Don't colorize the command output."),
-    )
 
     def __init__(self):
         super(Command, self).__init__()
@@ -87,6 +44,33 @@ class Command(TestCommand):
                 """
                 tasks += ('django_jenkins.tasks.with_coverage',)
         return tasks
+
+    def add_arguments(self, parser):
+        super(Command, self).add_arguments(parser)
+        parser.add_argument('--output-dir', dest='output_dir', default="reports",
+            help='Report files directory')
+        parser.add_argument("--enable-coverage",
+                        action="store_true", default=False,
+                        help="Measure code coverage")
+        parser.add_argument('--debug', action='store_true',
+                        dest='debug', default=False,
+                        help='Do not intercept stdout and stderr, friendly for console debuggers')
+        parser.add_argument("--coverage-rcfile",
+                        dest="coverage_rcfile",
+                        default="",
+                        help="Specify configuration file.")
+        parser.add_argument("--coverage-html-report",
+                        dest="coverage_html_report_dir",
+                        default="",
+                        help="Directory to which HTML coverage report should be"
+                        " written. If not specified, no report is generated.")
+        parser.add_argument("--coverage-exclude", action="append",
+                        default=[], dest="coverage_excludes",
+                        help="Module name to exclude")
+        parser.add_argument("--project-apps-tests", action="store_true",
+                        default=False, dest="project_apps_tests",
+                        help="Take tests only from project apps")
+
 
     def create_parser(self, prog_name, subcommand):
         test_runner_class = get_runner(settings, self.test_runner)

--- a/django_jenkins/tasks/__init__.py
+++ b/django_jenkins/tasks/__init__.py
@@ -4,6 +4,11 @@ import itertools
 from django.conf import settings
 from django.contrib.staticfiles import finders
 
+class ArgsparseMixin(object):
+
+    def add_arguments(self, parser):
+        ''' Entry points to add additionnal arguments on Reporter instead of using optparse '''
+        pass
 
 def static_files_iterator(tested_locations, extension, ignore_patterns=None, additional_settings_list=None):
     if ignore_patterns is None:

--- a/django_jenkins/tasks/run_csslint.py
+++ b/django_jenkins/tasks/run_csslint.py
@@ -4,18 +4,18 @@ import subprocess
 import codecs
 from optparse import make_option
 from django.conf import settings
-from django_jenkins.tasks import static_files_iterator
+from django_jenkins.tasks import static_files_iterator, ArgsparseMixin
 
 
-class Reporter(object):
-    option_list = (
-        make_option("--csslint-exclude",
+class Reporter(ArgsparseMixin):
+
+    def add_arguments(self, parser):
+        parser.add_argument("--csslint-exclude",
                     dest="csslint_exclude", default=".min.css",
-                    help="Comma separated exclude file patterns"),
-        make_option("--csslint-ignore",
+                    help="Comma separated exclude file patterns")
+        parser.add_argument("--csslint-ignore",
                     dest="csslint_ignore", default="",
                     help="CSSLint Ignore rules")
-    )
 
     def run(self, apps_locations, **options):
         output = codecs.open(os.path.join(options['output_dir'], 'csslint.report'), 'w', 'utf-8')

--- a/django_jenkins/tasks/run_flake8.py
+++ b/django_jenkins/tasks/run_flake8.py
@@ -28,7 +28,7 @@ class Reporter(ArgsparseMixin):
         parser.add_argument("--pep8-ignore", dest="pep8-ignore",
                     help="skip errors and warnings (e.g. E4,W)"),
         parser.add_argument("--pep8-max-line-length",
-                    dest="pep8-max-line-length", type='int',
+                    dest="pep8-max-line-length", type=int,
                     help="set maximum allowed line length (default: %d)" %
                     pep8.MAX_LINE_LENGTH),
         parser.add_argument("--pep8-rcfile", dest="pep8-rcfile",

--- a/django_jenkins/tasks/run_flake8.py
+++ b/django_jenkins/tasks/run_flake8.py
@@ -5,34 +5,34 @@ from flake8.engine import get_style_guide
 from django.conf import settings
 from optparse import make_option
 
-from . import set_option
+from . import set_option, ArgsparseMixin
 
 
-class Reporter(object):
+class Reporter(ArgsparseMixin):
     """
     Runs flake8 on python files.
     """
-    option_list = (
-        make_option('--max-complexity',
+
+    def add_arguments(self, parser):
+        parser.add_argument('--max-complexity',
                     dest='flake8-max-complexity',
                     type=int,
                     help='McCabe complexity treshold'),
-        make_option("--pep8-exclude",
+        parser.add_argument("--pep8-exclude",
                     dest="pep8-exclude",
                     help="exclude files or directories which match these "
                     "comma separated patterns (default: %s)" %
                     (pep8.DEFAULT_EXCLUDE + ",south_migrations")),
-        make_option("--pep8-select", dest="pep8-select",
+        parser.add_argument("--pep8-select", dest="pep8-select",
                     help="select errors and warnings (e.g. E,W6)"),
-        make_option("--pep8-ignore", dest="pep8-ignore",
+        parser.add_argument("--pep8-ignore", dest="pep8-ignore",
                     help="skip errors and warnings (e.g. E4,W)"),
-        make_option("--pep8-max-line-length",
+        parser.add_argument("--pep8-max-line-length",
                     dest="pep8-max-line-length", type='int',
                     help="set maximum allowed line length (default: %d)" %
                     pep8.MAX_LINE_LENGTH),
-        make_option("--pep8-rcfile", dest="pep8-rcfile",
+        parser.add_argument("--pep8-rcfile", dest="pep8-rcfile",
                     help="PEP8 configuration file"),
-    )
 
     def run(self, apps_locations, **options):
         output = open(os.path.join(options['output_dir'], 'flake8.report'), 'w')

--- a/django_jenkins/tasks/run_jshint.py
+++ b/django_jenkins/tasks/run_jshint.py
@@ -4,15 +4,15 @@ import codecs
 import subprocess
 from optparse import make_option
 from django.conf import settings
-from django_jenkins.tasks import static_files_iterator
+from django_jenkins.tasks import static_files_iterator, ArgsparseMixin
 
 
-class Reporter(object):
-    option_list = (
-        make_option("--jshint-exclude",
+class Reporter(ArgsparseMixin):
+
+    def add_arguments(self, parser):
+        parser.add_argument("--jshint-exclude",
                     dest="jshint_exclude", default="",
-                    help="Exclude patterns"),
-    )
+                    help="Exclude patterns")
 
     def run(self, apps_locations, **options):
         output = codecs.open(os.path.join(options['output_dir'], 'jshint.xml'), 'w', 'utf-8')

--- a/django_jenkins/tasks/run_pep8.py
+++ b/django_jenkins/tasks/run_pep8.py
@@ -19,7 +19,7 @@ class Reporter(ArgsparseMixin):
         parser.add_argument("--pep8-ignore", dest="pep8-ignore",
                     help="skip errors and warnings (e.g. E4,W)")
         parser.add_argument("--pep8-max-line-length",
-                    dest="pep8-max-line-length", type='int',
+                    dest="pep8-max-line-length", type=int,
                     help="set maximum allowed line length (default: %d)" %
                     pep8.MAX_LINE_LENGTH)
         parser.add_argument("--pep8-rcfile", dest="pep8-rcfile",

--- a/django_jenkins/tasks/run_pep8.py
+++ b/django_jenkins/tasks/run_pep8.py
@@ -3,27 +3,28 @@ import pep8
 from optparse import make_option
 from django.conf import settings
 
-from . import set_option
+from . import set_option, ArgsparseMixin
 
 
-class Reporter(object):
-    option_list = (
-        make_option("--pep8-exclude",
+class Reporter(ArgsparseMixin):
+
+    def add_arguments(self, parser):
+        parser.add_argument("--pep8-exclude",
                     dest="pep8-exclude",
                     help="exclude files or directories which match these "
                     "comma separated patterns (default: %s)" %
-                    (pep8.DEFAULT_EXCLUDE + ",south_migrations")),
-        make_option("--pep8-select", dest="pep8-select",
-                    help="select errors and warnings (e.g. E,W6)"),
-        make_option("--pep8-ignore", dest="pep8-ignore",
-                    help="skip errors and warnings (e.g. E4,W)"),
-        make_option("--pep8-max-line-length",
+                    (pep8.DEFAULT_EXCLUDE + ",south_migrations"))
+        parser.add_argument("--pep8-select", dest="pep8-select",
+                    help="select errors and warnings (e.g. E,W6)")
+        parser.add_argument("--pep8-ignore", dest="pep8-ignore",
+                    help="skip errors and warnings (e.g. E4,W)")
+        parser.add_argument("--pep8-max-line-length",
                     dest="pep8-max-line-length", type='int',
                     help="set maximum allowed line length (default: %d)" %
-                    pep8.MAX_LINE_LENGTH),
-        make_option("--pep8-rcfile", dest="pep8-rcfile",
+                    pep8.MAX_LINE_LENGTH)
+        parser.add_argument("--pep8-rcfile", dest="pep8-rcfile",
                     help="PEP8 configuration file")
-    )
+
 
     def run(self, apps_locations, **options):
         output = open(os.path.join(options['output_dir'], 'pep8.report'), 'w')

--- a/django_jenkins/tasks/run_pyflakes.py
+++ b/django_jenkins/tasks/run_pyflakes.py
@@ -10,15 +10,17 @@ try:
 except ImportError:
     from io import StringIO
 
+from django_jenkins.tasks import ArgsparseMixin
 
-class Reporter(object):
-    option_list = (
-        make_option("--pyflakes-exclude-dir",
+
+class Reporter(ArgsparseMixin):
+
+    def add_arguments(self, parser):
+        parser.add_argument("--pyflakes-exclude-dir",
                     action="append",
                     default=['south_migrations'],
                     dest="pyflakes_exclude_dirs",
-                    help="Path name to exclude"),
-    )
+                    help="Path name to exclude")
 
     def run(self, apps_locations, **options):
         output = open(os.path.join(options['output_dir'], 'pyflakes.report'), 'w')

--- a/django_jenkins/tasks/run_pylint.py
+++ b/django_jenkins/tasks/run_pylint.py
@@ -5,6 +5,8 @@ from django.conf import settings
 from pylint import lint
 from pylint.reporters.text import TextReporter
 
+from django_jenkins.tasks import ArgsparseMixin
+
 
 class ParseableTextReporter(TextReporter):
     """
@@ -16,23 +18,22 @@ class ParseableTextReporter(TextReporter):
     line_format = '{path}:{line}: [{msg_id}({symbol}), {obj}] {msg}'
 
 
-class Reporter(object):
-    option_list = (
-        make_option("--pylint-rcfile",
+class Reporter(ArgsparseMixin):
+
+    def add_arguments(self, parser):
+        parser.add_argument("--pylint-rcfile",
                     dest="pylint_rcfile",
-                    help="pylint configuration file"),
-        make_option("--pylint-errors-only",
+                    help="pylint configuration file")
+        parser.add_argument("--pylint-errors-only",
                     dest="pylint_errors_only",
                     action="store_true", default=False,
-                    help="pylint output errors only mode"),
-        make_option("--pylint-load-plugins",
+                    help="pylint output errors only mode")
+        parser.add_argument("--pylint-load-plugins",
                     dest="pylint_load_plugins",
-                    help="list of pylint plugins to load"),
-    )
+                    help="list of pylint plugins to load")
 
     def run(self, apps_locations, **options):
         output = open(os.path.join(options['output_dir'], 'pylint.report'), 'w')
-
         args = []
         args.append("--rcfile=%s" % self.get_config_path(options))
         if self.get_plugins(options):

--- a/django_jenkins/tasks/run_scsslint.py
+++ b/django_jenkins/tasks/run_scsslint.py
@@ -4,15 +4,20 @@ import subprocess
 import codecs
 from optparse import make_option
 from django.conf import settings
-from django_jenkins.tasks import static_files_iterator
+from django_jenkins.tasks import static_files_iterator, ArgsparseMixin
 
 
-class Reporter(object):
+class Reporter(ArgsparseMixin):
     option_list = (
         make_option("--scss-lint-exclude",
                     dest="scss_lint_exclude", default="",
                     help="Comma separated exclude file patterns"),
     )
+
+    def add_arguments(self, parser):
+        parser.add_argument("--scss-lint-exclude",
+                    dest="scss_lint_exclude", default="",
+                    help="Comma separated exclude file patterns")
 
     def run(self, apps_locations, **options):
         output = codecs.open(os.path.join(options['output_dir'], 'scss-lint.xml'), 'w', 'utf-8')

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ from setuptools import setup
 read = lambda filepath: codecs.open(filepath, 'r', 'utf-8').read()
 
 install_requires=[
-    'Django>=1.6',
+    'Django>=1.8',
 ]
 
 # Needed for Python <2.7


### PR DESCRIPTION
This addresses the following issue : https://code.djangoproject.com/ticket/24518 due to backward compatibility : https://docs.djangoproject.com/en/1.8/releases/1.8/#custom-test-management-command-arguments-through-test-runner

This pull request is not ready for merging since there is no management of backward compatibility (thus I updated the minimum django version to 1.8).

It's just a quick fix that I needed so I share it here in order that someone handle it properly.