### PR TITLE
fix deprecation warning for django 1.8 with importlib

### DIFF
--- a/django_jenkins/management/commands/jenkins.py
+++ b/django_jenkins/management/commands/jenkins.py
@@ -6,7 +6,11 @@ from optparse import OptionParser, make_option
 import django
 from django.conf import settings
 from django.core.management.commands.test import Command as TestCommand
-from django.utils.importlib import import_module
+
+try:
+    from importlib import import_module
+except ImportError:
+    from django.utils.importlib import import_module
 
 from django_jenkins.runner import CITestSuiteRunner
 
@@ -194,7 +198,10 @@ class Command(TestCommand):
                     warnings.warn('No app found for test: {0}'.format(test_label))
         except ImportError:
             # django 1.6
-            from django.utils.importlib import import_module
+            try:
+                from importlib import import_module
+            except ImportError:
+                from django.utils.importlib import import_module
 
             def get_containing_app(object_name):
                 candidates = []

--- a/django_jenkins/management/commands/jenkins.py
+++ b/django_jenkins/management/commands/jenkins.py
@@ -198,10 +198,7 @@ class Command(TestCommand):
                     warnings.warn('No app found for test: {0}'.format(test_label))
         except ImportError:
             # django 1.6
-            try:
-                from importlib import import_module
-            except ImportError:
-                from django.utils.importlib import import_module
+            from importlib import import_module
 
             def get_containing_app(object_name):
                 candidates = []

--- a/django_jenkins/tasks/with_coverage.py
+++ b/django_jenkins/tasks/with_coverage.py
@@ -2,7 +2,11 @@ import warnings
 import os
 import sys
 from django.conf import settings
-from django.utils.importlib import import_module
+
+try:
+    from importlib import import_module
+except ImportError:
+    from django.utils.importlib import import_module
 
 
 def default_coverage_config():

--- a/setup.py
+++ b/setup.py
@@ -8,6 +8,15 @@ from setuptools import setup
 
 read = lambda filepath: codecs.open(filepath, 'r', 'utf-8').read()
 
+install_requires = [
+    'Django>=1.6',
+]
+
+# Needed for Python <2.7
+try:
+    import importlib
+except ImportError:
+    install_requires.append(['importlib'])
 
 setup(
     name='django-jenkins',
@@ -35,9 +44,7 @@ setup(
         'Topic :: Software Development :: Libraries :: Python Modules',
         'Topic :: Software Development :: Testing'
     ],
-    install_requires=[
-        'Django>=1.6',
-    ],
+    install_requires=install_requires,
     packages=['django_jenkins', 'django_jenkins.management',
               'django_jenkins.tasks', 'django_jenkins.management.commands'],
     package_data={'django_jenkins': ['tasks/pylint.rc']},


### PR DESCRIPTION
It hides irritating warnings in django 1.8