### PR TITLE
Fix deprecated pylint include-ids warning

### DIFF
--- a/django_jenkins/tasks/pylint.rc
+++ b/django_jenkins/tasks/pylint.rc
@@ -22,7 +22,6 @@ disable=C0111,I0011,I0012,W0704,W0142,W0212,W0232,W0613,W0702,R0201,C1001,C0103,
 
 [REPORTS]
 msg-template={path}:{line}: [{msg_id}({symbol}), {obj}] {msg}
-include-ids=yes
 
 
 [BASIC]


### PR DESCRIPTION
Fixes this warning:

    Warning: option include-ids is deprecated and ignored.