### PR TITLE
fix the check for coverage

### DIFF
--- a/django_jenkins/tasks/with_coverage.py
+++ b/django_jenkins/tasks/with_coverage.py
@@ -9,20 +9,21 @@ class CoverageReporter(object):
     def __init__(self):
         try:
             import coverage
-            if coverage.__version__ < '4':
-                raise ImportError('coverage>=4 required')
         except ImportError:
             raise ImportError('coverage is not installed')
-        else:
-            coverage_config_file = None
-            for argv in sys.argv:
-                if argv.startswith('--coverage-rcfile='):
-                    _, coverage_config_file = argv.split('=')
 
-            self.coverage = coverage.coverage(
-                branch=True,
-                config_file=coverage_config_file or self.default_coverage_config())
-            self.coverage.start()
+        if coverage.__version__ < '4':
+            raise ImportError('coverage>=4 required')
+
+        coverage_config_file = None
+        for argv in sys.argv:
+            if argv.startswith('--coverage-rcfile='):
+                _, coverage_config_file = argv.split('=')
+
+        self.coverage = coverage.coverage(
+            branch=True,
+            config_file=coverage_config_file or self.default_coverage_config())
+        self.coverage.start()
 
     def save(self, apps_locations, options):
         self.coverage.stop()


### PR DESCRIPTION
With the previous structure, if the coverage version was too old, the
raised exception for old version would never be seen. The enclosing
try-except block would catch it and the user would get the confusing
warning that coverage was not installed.

Instead, we get rid of the except and we check for the coverage
version outside of a try-except block. There's also no need to
except-else, since the original except block was raising again, and
thus the except-block would never be reached.