### PR TITLE
Allow using of 'source' from coverage-rcfile

### DIFF
--- a/django_jenkins/management/commands/jenkins.py
+++ b/django_jenkins/management/commands/jenkins.py
@@ -170,10 +170,14 @@ class Command(TestCommand):
     def get_tested_locations(self, test_labels):
         locations = []
 
+        coverage = apps.get_app_config('django_jenkins').coverage
         if test_labels:
             pass
         elif hasattr(settings, 'PROJECT_APPS'):
             test_labels = settings.PROJECT_APPS
+        elif coverage.coverage.source:
+            warnings.warn("No PROJECT_APPS settings, using 'source' config from rcfile")
+            locations = coverage.coverage.source
         else:
             warnings.warn('No PROJECT_APPS settings, coverage gathered over all apps')
             test_labels = settings.INSTALLED_APPS


### PR DESCRIPTION
Sometimes, I'd like coverage reports for modules that aren't necessarily Django apps

The way it's set up now, only modules that are valid Django apps (and are hence accessible from `apps.get_containing_app_config(test_label)`) can be added to `tested_locations`, and the `[source]` config in `--coverage-rcfile` is ignored.

This way, devs get to choose if they want coverage reports for only Django apps (via `PROJECT_APPS`/`INSTALLED_APPS`), or arbitrary modules (via `[source]` in `--coverage-rcfile`)

