### PR TITLE
Enable the disabling of tasks using an option

### DIFF
--- a/django_jenkins/management/commands/jenkins.py
+++ b/django_jenkins/management/commands/jenkins.py
@@ -64,9 +64,9 @@ class Command(TestCommand):
                             default=False, dest="project_apps_tests",
                             help="Take tests only from project apps")
 
-        TestRunner = get_runner(settings)
-        if TestRunner:
-            TestRunner().add_arguments(parser)
+        test_runner_class = get_runner(settings)
+        if hasattr(test_runner_class, 'add_arguments'):
+            test_runner_class.add_arguments(parser)
 
         parser._optionals.conflict_handler = 'resolve'
         for task in self.tasks:

--- a/django_jenkins/management/commands/jenkins.py
+++ b/django_jenkins/management/commands/jenkins.py
@@ -66,7 +66,7 @@ class Command(TestCommand):
 
         test_runner_class = get_runner(settings)
         if hasattr(test_runner_class, 'add_arguments'):
-            test_runner_class().add_arguments(parser)
+            test_runner_class.add_arguments(parser)
 
         parser._optionals.conflict_handler = 'resolve'
         for task in self.tasks:

--- a/django_jenkins/management/commands/jenkins.py
+++ b/django_jenkins/management/commands/jenkins.py
@@ -66,7 +66,7 @@ class Command(TestCommand):
 
         test_runner_class = get_runner(settings)
         if hasattr(test_runner_class, 'add_arguments'):
-            test_runner_class.add_arguments(parser)
+            test_runner_class().add_arguments(parser)
 
         parser._optionals.conflict_handler = 'resolve'
         for task in self.tasks:

--- a/django_jenkins/management/commands/jenkins.py
+++ b/django_jenkins/management/commands/jenkins.py
@@ -64,6 +64,10 @@ class Command(TestCommand):
                             default=False, dest="project_apps_tests",
                             help="Take tests only from project apps")
 
+        TestRunner = get_runner(settings)
+        if TestRunner:
+            TestRunner().add_arguments(parser)
+
         parser._optionals.conflict_handler = 'resolve'
         for task in self.tasks:
             if hasattr(task, 'add_arguments'):

--- a/django_jenkins/tasks/run_jshint.py
+++ b/django_jenkins/tasks/run_jshint.py
@@ -12,8 +12,12 @@ class Reporter(object):
         parser.add_argument("--jshint-exclude",
                             dest="jshint_exclude", default="",
                             help="Exclude patterns")
+        parser.add_argument("--jshint-disable", dest="jshint-disable",
+                            help="Disable the jshint task", action='store_true')
 
     def run(self, apps_locations, **options):
+        if options['jshint-disable']:
+            return
         output = codecs.open(os.path.join(options['output_dir'], 'jshint.xml'), 'w', 'utf-8')
 
         files = list(

--- a/django_jenkins/tasks/run_pep8.py
+++ b/django_jenkins/tasks/run_pep8.py
@@ -22,8 +22,13 @@ class Reporter(object):
                             help="set maximum allowed line length (default: %d)" % pep8.MAX_LINE_LENGTH)
         parser.add_argument("--pep8-rcfile", dest="pep8-rcfile",
                             help="PEP8 configuration file")
+        parser.add_argument("--pep8-disable", dest="pep8-disable",
+                            help="Disable the PEP8 task", action='store_true')
 
     def run(self, apps_locations, **options):
+        if options['pep8-disable']:
+            return
+
         output = open(os.path.join(options['output_dir'], 'pep8.report'), 'w')
 
         class JenkinsReport(pep8.BaseReport):

--- a/django_jenkins/tasks/run_pyflakes.py
+++ b/django_jenkins/tasks/run_pyflakes.py
@@ -17,8 +17,12 @@ class Reporter(object):
                             default=['south_migrations'],
                             dest="pyflakes_exclude_dirs",
                             help="Path name to exclude")
+        parser.add_argument("--pyflakes-disable", action='store_true', dest="pyflakes-disable",
+                            help="Disable the pyflakes task")
 
     def run(self, apps_locations, **options):
+        if options['pyflakes-disable']:
+            return
         output = open(os.path.join(options['output_dir'], 'pyflakes.report'), 'w')
 
         # run pyflakes tool with captured output

--- a/django_jenkins/tasks/run_pylint.py
+++ b/django_jenkins/tasks/run_pylint.py
@@ -28,8 +28,12 @@ class Reporter(object):
         parser.add_argument("--pylint-load-plugins",
                             dest="pylint_load_plugins",
                             help="list of pylint plugins to load")
+        parser.add_argument("--pylint-disable", action='store_true', dest="pylint-disable",
+                            help="Disable the pylint task")
 
     def run(self, apps_locations, **options):
+        if options['pylint-disable']:
+            return
         output = open(os.path.join(options['output_dir'], 'pylint.report'), 'w')
 
         args = []


### PR DESCRIPTION
In our setup we would like to be able to control which tasks we run without playing with our setting file.

Those options enable us to do that.