### PR TITLE
Check that coverage is not None

### DIFF
--- a/django_jenkins/management/commands/jenkins.py
+++ b/django_jenkins/management/commands/jenkins.py
@@ -132,7 +132,7 @@ class Command(TestCommand):
             pass
         elif hasattr(settings, 'PROJECT_APPS'):
             test_labels = settings.PROJECT_APPS
-        elif coverage.coverage.source:
+        elif coverage and coverage.coverage.source:
             warnings.warn("No PROJECT_APPS settings, using 'source' config from rcfile")
             locations = coverage.coverage.source
         else:


### PR DESCRIPTION
When running `manage.py jenkins` without `--enable-coverage` it crashes due to coverage being `None`

Traceback:
```
Traceback (most recent call last):
  File "manage.py", line 10, in <module>
    execute_from_command_line(sys.argv)
  File "/Users/tbartelmess/.pyenv/versions/<REDACTED>/lib/python3.5/site-packages/django/core/management/__init__.py", line 353, in execute_from_command_line
    utility.execute()
  File "/Users/tbartelmess/.pyenv/versions/<REDACTED>/lib/python3.5/site-packages/django/core/management/__init__.py", line 345, in execute
    self.fetch_command(subcommand).run_from_argv(self.argv)
  File "/Users/tbartelmess/.pyenv/versions/<REDACTED>/lib/python3.5/site-packages/django_jenkins/management/commands/jenkins.py", line 47, in run_from_argv
    super(Command, self).run_from_argv(argv)
  File "/Users/tbartelmess/.pyenv/versions/<REDACTED>/lib/python3.5/site-packages/django/core/management/commands/test.py", line 30, in run_from_argv
    super(Command, self).run_from_argv(argv)
  File "/Users/tbartelmess/.pyenv/versions/<REDACTED>/lib/python3.5/site-packages/django/core/management/base.py", line 348, in run_from_argv
    self.execute(*args, **cmd_options)
  File "/Users/tbartelmess/.pyenv/versions/<REDACTED>/lib/python3.5/site-packages/django/core/management/commands/test.py", line 74, in execute
    super(Command, self).execute(*args, **options)
  File "/Users/tbartelmess/.pyenv/versions/<REDACTED>/lib/python3.5/site-packages/django/core/management/base.py", line 399, in execute
    output = self.handle(*args, **options)
  File "/Users/tbartelmess/.pyenv/versions/<REDACTED>/lib/python3.5/site-packages/django_jenkins/management/commands/jenkins.py", line 109, in handle
    tested_locations = self.get_tested_locations(test_labels)
  File "/Users/tbartelmess/.pyenv/versions/<REDACTED>/lib/python3.5/site-packages/django_jenkins/management/commands/jenkins.py", line 135, in get_tested_locations
    elif coverage.coverage.source:
AttributeError: 'NoneType' object has no attribute 'coverage'

```