### PR TITLE
Ignore migrations directory by default

### DIFF
--- a/django_jenkins/tasks/pylint.rc
+++ b/django_jenkins/tasks/pylint.rc
@@ -1,6 +1,6 @@
 [MASTER]
 persistent=yes
-ignore=south_migrations
+ignore=south_migrations,migrations
 cache-size=500
 
 [MESSAGES CONTROL]


### PR DESCRIPTION
May make sense to ignore migrations folder by default in pylint, what do you think?