### PR TITLE
Task for scss-lint tool

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -5,7 +5,7 @@ Plug and play continuous integration with Django and Jenkins
 
 .. image:: https://img.shields.io/pypi/v/django-jenkins.svg
     :target: https://pypi.python.org/pypi/django-jenkins
-    
+
 .. image:: https://requires.io/github/kmmbvnr/django-jenkins/requirements.png?branch=master
    :target: https://requires.io/github/kmmbvnr/django-jenkins/requirements/?branch=master
 
@@ -92,6 +92,16 @@ Here is the reporters prebuild with django-jenkins
   Creates CSS Lint compatible report for Jenkins
 
   You should have the csslint package installed
+
+- ``django_jenkins.tasks.run_scsslint``
+
+  Runs SCSS lint tool over `app/static/*/*.scss` files.
+  Creates CSS Lint compatible report for Jenkins
+
+  You should have the scss-lint_ and scss_lint_reporter_checkstyle_ tools installed
+
+.. _scss-lint: https://github.com/brigade/scss-lint
+.. _scss_lint_reporter_checkstyle: https://github.com/Sweetchuck/scss_lint_reporter_checkstyle
 
 - ``django_jenkins.tasks.run_pep8``
 

--- a/django_jenkins/tasks/run_scsslint.py
+++ b/django_jenkins/tasks/run_scsslint.py
@@ -1,0 +1,42 @@
+# -*- coding: utf-8; mode: django -*-
+import os
+import subprocess
+import codecs
+
+from django.conf import settings
+from django_jenkins.tasks import static_files_iterator
+
+
+class Reporter(object):
+    def add_arguments(self, parser):
+        parser.add_argument("--scss-lint-exclude",
+                            dest="scss_lint_exclude", default="",
+                            help="Comma separated exclude file patterns")
+
+    def run(self, apps_locations, **options):
+        output = codecs.open(os.path.join(options['output_dir'], 'scss-lint.xml'), 'w', 'utf-8')
+
+        files = list(
+            static_files_iterator(apps_locations + list(getattr(settings, 'STATICFILES_DIRS', [])),
+                                  extension='.scss',
+                                  ignore_patterns=options['scss_lint_exclude'].split(',')))
+
+        if files:
+            cmd = ['scss-lint', '--require=scss_lint_reporter_checkstyle', '--format=Checkstyle'] + files
+
+            config_file = getattr(settings, 'SCSS_LINT_CONFIG_FILE', None)
+            if config_file:
+                cmd += ['--config=%s' % config_file]
+
+            process = subprocess.Popen(cmd, stdout=subprocess.PIPE)
+            process_output, err = process.communicate()
+            retcode = process.poll()
+            if retcode not in [0, 1, 2]:  # normal scss-lint return codes
+                raise subprocess.CalledProcessError(retcode, cmd, output='%s\n%s' % (output, err))
+
+            output.write(process_output.decode('utf-8'))
+        else:
+            output.write('<?xml version="1.0" encoding='
+                         '"utf-8"?><lint></lint>')
+
+        output.close()

--- a/tests/settings.py
+++ b/tests/settings.py
@@ -61,6 +61,7 @@ JENKINS_TASKS = (
     'django_jenkins.tasks.run_pylint',
     'django_jenkins.tasks.run_pep8',
     'django_jenkins.tasks.run_csslint',
+    'django_jenkins.tasks.run_scsslint',
     'django_jenkins.tasks.run_flake8',
     'django_jenkins.tasks.run_pyflakes',
     'django_jenkins.tasks.run_jshint',


### PR DESCRIPTION
Support for `scss-lint` was removed in 184e64c5a3d05710b445a3103545f10c207fd150, since the linter dropped support for XML output.

XML output is now available with [scss_lint_reporter_checkstyle](https://github.com/Sweetchuck/scss_lint_reporter_checkstyle) formatter. I've updated the task to use this formatter, and it should now function again with Jenkins.

It would be nice to have this task available in django-jenkins again!