### PR TITLE
Python2.7 django version fix 

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -40,8 +40,10 @@ setup(
         'Topic :: Software Development :: Testing'
     ],
     install_requires=[
-        'Django>=1.8',
+        'Django>=1.8,<=1.11; python_version<="2.7"', 
+        'Django>=1.8; python_version>"2.7"',
     ],
+
     packages=['django_jenkins', 'django_jenkins.management',
               'django_jenkins.tasks', 'django_jenkins.management.commands'],
     package_data={'django_jenkins': ['tasks/pylint.rc']},

--- a/setup.py
+++ b/setup.py
@@ -43,7 +43,6 @@ setup(
         'Django>=1.8,<=1.11; python_version<="2.7"', 
         'Django>=1.8; python_version>"2.7"',
     ],
-
     packages=['django_jenkins', 'django_jenkins.management',
               'django_jenkins.tasks', 'django_jenkins.management.commands'],
     package_data={'django_jenkins': ['tasks/pylint.rc']},

--- a/setup.py
+++ b/setup.py
@@ -40,7 +40,7 @@ setup(
         'Topic :: Software Development :: Testing'
     ],
     install_requires=[
-        'Django>=1.8,<=1.11; python_version<="2.7"', 
+        'Django>=1.8,<2.0; python_version<="2.7"', 
         'Django>=1.8; python_version>"2.7"',
     ],
     packages=['django_jenkins', 'django_jenkins.management',


### PR DESCRIPTION
Pinning down versions for django for python2.7. Python 2.7 is currently not compatible with the django 2.0 release. 

This is in response for issue: https://github.com/kmmbvnr/django-jenkins/issues/362
