### PR TITLE
Fix the JUnit schema by changing 'skips' to 'skipped'

### DIFF
--- a/django_jenkins/runner.py
+++ b/django_jenkins/runner.py
@@ -78,7 +78,7 @@ class EXMLTestResult(TextTestResult):
         self.tree.set('name', 'Django Project Tests')
         self.tree.set('errors', str(len(self.errors)))
         self.tree.set('failures', str(len(self.failures)))
-        self.tree.set('skips', str(len(self.skipped)))
+        self.tree.set('skipped', str(len(self.skipped)))
         self.tree.set('tests', str(self.testsRun))
         self.tree.set('time', "%.3f" % run_time_taken)
         super(EXMLTestResult, self).stopTestRun()


### PR DESCRIPTION
The Jenkins xUnit plugin had a major update (https://wiki.jenkins.io/display/JENKINS/xUnit+Plugin, search for Version 2.0.0) that enforced strict checking of junit.xml files according to the XSD provided by Surefire / Ant Junit.

According to that XSD, `skips` is not allowed in `<testsuite>`, it should be `skipped`. This PR changes that in the `runner` module.