### PR TITLE
docs: Fix simple typo, volounters -> volunteers

### DIFF
--- a/django_jenkins/tasks/run_flake8.py
+++ b/django_jenkins/tasks/run_flake8.py
@@ -8,7 +8,7 @@ except ImportError:
     from io import StringIO
 
 
-from flake8.api.legacy import get_style_guide  # Quck hack again, 3d time flake8 would be removed, if no volounters found
+from flake8.api.legacy import get_style_guide  # Quck hack again, 3d time flake8 would be removed, if no volunteers found
 from django.conf import settings
 
 from . import set_option


### PR DESCRIPTION
There is a small typo in django_jenkins/tasks/run_flake8.py.

Should read `volunteers` rather than `volounters`.

